### PR TITLE
minor fixes for GET prepacking events endpoint

### DIFF
--- a/src/main/java/org/openlmis/prepacking/repository/PrepackingEventsRepository.java
+++ b/src/main/java/org/openlmis/prepacking/repository/PrepackingEventsRepository.java
@@ -26,4 +26,8 @@ public interface PrepackingEventsRepository extends
     PagingAndSortingRepository<PrepackingEvent, UUID> {
   List<PrepackingEvent> findByProgramId(@Param("programId") UUID programId);
 
+  List<PrepackingEvent> findByFacilityId(@Param("facilityId") UUID facilityId);
+  
+  List<PrepackingEvent> findByFacilityIdAndProgramId(@Param("facilityId") UUID facilityId,@Param("programId") UUID programId);
+
 }

--- a/src/main/java/org/openlmis/prepacking/web/PrepackingController.java
+++ b/src/main/java/org/openlmis/prepacking/web/PrepackingController.java
@@ -91,17 +91,17 @@ public class PrepackingController extends BaseController {
   /**
    * List prepacking event.
    *
-   * @param destinationId a destination facility id.
+   * @param facilityId a destination facility id.
    * @return List of prepacking events.
    */
   @RequestMapping(method = GET)
   public ResponseEntity<List<PrepackingEventDto>> getPrepackingEvents(
-      @RequestParam() UUID destinationId) {
+      @RequestParam() UUID facilityId) {
 
     LOGGER.debug("Try to load prepacking events");
 
     List<PrepackingEventDto> prepacksToReturn;
-    prepacksToReturn = prepackingService.getPrepackingEventsByProgramId(destinationId);
+    prepacksToReturn = prepackingService.getPrepackingEventsByFacilityId(facilityId);
 
     return new ResponseEntity<>(prepacksToReturn, OK);
   }


### PR DESCRIPTION
1. Repository fixes
- re-added method to retrieve prepacking events by facility id
- re-added method to retrieve prepacking events by facility id and program id
2. Controller fixes
-renamed destinationId to facilityId
-modifed get endpoint to retrieve events by facilityId