### PR TITLE
included prepacker id and usernames in result

### DIFF
--- a/src/main/java/org/openlmis/prepacking/domain/event/PrepackingEvent.java
+++ b/src/main/java/org/openlmis/prepacking/domain/event/PrepackingEvent.java
@@ -55,7 +55,8 @@ public class PrepackingEvent extends BaseEntity {
   private UUID facilityId;
   private UUID programId;
   private String comments;
-
+  private UUID prepackerUserId;
+  private String prepackerUserNames;
   @Column(nullable = false)
   @Enumerated(EnumType.STRING)
   @Getter

--- a/src/main/java/org/openlmis/prepacking/dto/PrepackingEventDto.java
+++ b/src/main/java/org/openlmis/prepacking/dto/PrepackingEventDto.java
@@ -51,12 +51,12 @@ public class PrepackingEventDto {
   private UUID facilityId;
   private UUID programId;
   private String comments;
+  private UUID prepackerUserId;
+  private String prepackerUserNames;
   private PrepackingEventStatus status;
   private String draftStatusMessage;
-  private String remarks;
   private List<PrepackingEventLineItemDto> lineItems;
   private ExtraDataEntity extraData = new ExtraDataEntity();
-
   private PrepackingEventProcessContext context;
 
   /**
@@ -66,7 +66,7 @@ public class PrepackingEventDto {
    */
   public PrepackingEvent toPrepackingEvent() {
     PrepackingEvent prepackingEvent = new PrepackingEvent(
-        now(), facilityId, programId, comments, status,draftStatusMessage,lineItems(),extraData);
+        now(),facilityId,programId,comments,context.getCurrentUserId(),context.getCurrentUserNames(),status,draftStatusMessage,lineItems(),extraData);
     return prepackingEvent;
   }
 

--- a/src/main/java/org/openlmis/prepacking/service/PrepackingService.java
+++ b/src/main/java/org/openlmis/prepacking/service/PrepackingService.java
@@ -147,6 +147,12 @@ public class PrepackingService {
     if (incomingPrepackingEvent.getComments() != null) {
       existingPrepackingEvent.setComments(incomingPrepackingEvent.getComments());
     }
+    if (incomingPrepackingEvent.getPrepackerUserId() != null) {
+      existingPrepackingEvent.setPrepackerUserId(incomingPrepackingEvent.getPrepackerUserId());
+    }
+    if (incomingPrepackingEvent.getPrepackerUserNames() != null) {
+      existingPrepackingEvent.setPrepackerUserNames(incomingPrepackingEvent.getPrepackerUserNames());
+    }
     if (incomingPrepackingEvent.getStatus() != null) {
       existingPrepackingEvent.setStatus(incomingPrepackingEvent.getStatus());
     }
@@ -206,6 +212,8 @@ public class PrepackingService {
         .facilityId(prepackingEvent.getFacilityId())
         .programId(prepackingEvent.getProgramId())
         .comments(prepackingEvent.getComments())
+        .prepackerUserId(prepackingEvent.getPrepackerUserId())
+        .prepackerUserNames(prepackingEvent.getPrepackerUserNames())
         .status(prepackingEvent.getStatus())
         .lineItems(prepackingEventLineItemsToDtos(prepackingEvent.getLineItems()))
         .build();


### PR DESCRIPTION
1. Data model
- added prepackerUserId and prepackerUserNames fields to the PrepackingEvent domain
-  added prepackerUserId and prepackerUserNames fields to the PrepackingEventDto 

2. Service
- extended the service implementation to retrieve user id and user names fields from either the authentication object or from the request payload and load them into the context
- extended the rest of the service implementation to align with the extended data model